### PR TITLE
Add notice for ChromeOS users above v115/v116

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@
 
 </div>
 
+## NOTICE
+
+A recent update to ChromeOS (v115/v116) released in August 2023 has blocked all javascript: and javascript:// bookmarklets. If you use a managed Chromebook and **Devtools are turned off** (that means Inspect element, etc.) (they must be turned off or bookmarklets still work) then the Car Axle Client Bookmarklet won't work.
+
 ## Features
 
 -   Exploits and history flooder


### PR DESCRIPTION
The chromos v115/v116 blocks all javascript: urls